### PR TITLE
Remove the complication of treating case class and string

### DIFF
--- a/docs/src/main/tut/examples.md
+++ b/docs/src/main/tut/examples.md
@@ -31,8 +31,7 @@ res2: String = The a, b and c are: ghi, xyz, C@3aaeb14
 
 // safeStr interpolation
 scala> safeStr"The a, b and c are: ${a}, ${b}, ${c}"
-<console>:24: error: The provided type is neither a string nor a case-class. Consider converting it to strings using <value>.asStr.
-       safeStr"The a, b and c are: ${a}, ${b}, ${c}"
+<console>:18: error: unable to find a safe instance for class C. Make sure it is a case class or a type that has safe instance.
                                                                                                     ^
 scala> safeStr"a and b: ${a}, ${b}"
 res2: com.thaj.safe.string.interpolator.SafeString = SafeString(a and b: ghi, xyz)

--- a/docs/src/main/tut/index.md
+++ b/docs/src/main/tut/index.md
@@ -49,11 +49,11 @@ defined class X
 scala> val caseClassInstance = X("foo")
 caseClassInstance: X = X(foo)
 
-scala> val onlyString: String = "bar"
+scala> val string: String = "bar"
 onlyString: String = bar
 
-scala> safeStr"Works only if its either a string or a case class instance $caseClassInstance or $onlyString"
-res0: com.thaj.safe.string.interpolator.SafeString = SafeString(Works only if its either a string or a case class instance { name: foo } or bar)
+scala> safeStr"Works only if all of them has an instance of safe $caseClassInstance or $string"
+res0: com.thaj.safe.string.interpolator.SafeString = SafeString(Works only if it all of them has an instance of safe { name : foo } or bar)
 
 scala> class C
 defined class C
@@ -62,24 +62,27 @@ scala> val nonCaseClass = new C
 nonCaseClass: C = C@7e3131c8
 
 scala> safeStr"Doesn't work if there is a non-case class $nonCaseClass or $onlyString"
-<console>:17: error: The provided type is neither a string nor a case-class. Consider converting it to strings using <value>.asStr.
-       safeStr"Doesn't work if there is a non-case class $nonCaseClass or $onlyString"
+<console>:17: error: unable to find a safe instance for class C. Make sure it is a case class or a type that has safe instance.
                                                           ^
 // And don't cheat by `toString`
 scala> safeStr"Doesn't work if there is a non-case class ${nonCaseClass.toString} or $onlyString"
-<console>:17: error: Identified `toString` being called on the types. Either remove it or use <yourType>.asStr if it has an instance of Safe.
-       safeStr"Doesn't work if there is a non-case class ${nonCaseClass.toString} or $onlyString"
+<console>:17: error: Identified `toString` being called on the types. Make sure the type has a instance of Safe..
                                                                         ^
-
 ```
 
 # Concept and example usages.
 
-`safeStr""` is just like `s""` in scala, but it is type safe and _allows only_ 
+`safeStr""` is just like `s""` in scala, but it is type safe and _allows only_ types that has a safe instance.
 
-* **strings**.
-* **case classes** which will be converted to json-like string by inspecting all fields, be it deeply nested or not, at compile time.
-* and provides consistent way to **hide secrets**.
+But don't worry. If you have a case class, the macros in `Safe.scala` will automatically derive it's safe instance
+as far as all ofthe individual fields has `Safe` instance which is also defined already in the companion object of `Safe`.
+It works for any deep/nested level of case classes.
+
+To sum up,
+
+* Most of the types already has a Safe instance in companion object, hence `Int`, `Double` etc works straight away.
+* **case classes**  will be converted to json-like string by inspecting all fields, be it deeply nested or not, at compile time.
+* `Secret` types will be hidden too. We will see more on these in the below links.
 
 To understand more on the concepts and usages, please go through:
 

--- a/docs/src/main/tut/pretty_print.md
+++ b/docs/src/main/tut/pretty_print.md
@@ -17,61 +17,17 @@ s: Xyz = Xyz(Abc(a,b,c),x)
 
 // scala string interpolation
 scala> s"The value of xyz is $s"
-res0: String = The value of xyz is Xyz(Abc(a,b,c),x)
+res5: String = The value of xyz is Xyz(Abc(a,b,c),x)
 
 // type safe string interpolation
 scala> safeStr"The value of xyz is $s"
-res1: com.thaj.safe.string.interpolator.SafeString = SafeString(The value of xyz is { name: x, abc: {x : a, y : b, z : c} })
+res6: com.thaj.safe.string.interpolator.SafeString = SafeString(The value of xyz is { abc : { a : a, b : b, c : c }, name : x })
 
 scala> res1.string
-res2: The value of xyz is { name: x, abc: {x : a, y : b, z : c} }
+res7: String = The value of xyz is { abc : { a : a, b : b, c : c }, name : x }
 ```
 
 
 This works for any level of **deep nested structure of case class**. This is done with the support of macro materializer in `Safe.scala`.
 The main idea here is, if any field in any part of the nested case class isn't safe to be converted to string, it will throw a compile time.
 Also, if any part of case classes has `Secret`s in it, the value will be hidden. More on this in `Secret / Password` section
-
-## Why case-classes ?
-
-While the purpose of `safe-string-interpolation` is to make sure you are passing only Strings to `safeStr`, it works for case-class instances as well.
-There is a reason for this.
-
-Delegating the job of stringifying a case class to the user has always been an infamous problem and it kills the user's time.
-The `safe-string-interpolation` takes up this tedious job, and macros under the hood converts it to a readable string, while hiding `Secret` types.
-
-PS: In the next release, we may ask the user to do `.asStr` explicitly on case classes as well. This will bring in more consistency.
-
-```scala
-
-@ import com.thaj.safe.string.interpolator.SafeString._
-import com.thaj.safe.string.interpolator.SafeString._
-
-@ case class Test(list: List[String])
-defined class Test
-
-@ val test = Test(List("foo", "bar"))
-test: Test = Test(List("foo", "bar"))
-
-@ safeStr"test will work $test"
-res4: com.thaj.safe.string.interpolator.SafeString = SafeString("test will work { list: foo,bar }")
-
-@ val test = List("foo", "bar")
-test: List[String] = List("foo", "bar")
-
-@ safeStr"test will not work $test"
-cmd6.sc:1: The provided type isn't a string nor it's a case class, or you might have tried a `toString` on non-strings !
-val res6 = safeStr"test will not work $test"
-                                       ^
-Compilation Failed
-
-@ safeStr"test will work by telling the compiler, yes, it is a string ${test.toString}"
-cmd6.sc:1: Identified `toString` being called on the types. Either remove it or use <yourType>.asStr if it has an instance of Safe.
-val res6 = safeStr"test will work by telling the compiler, yes, it is a string ${test.toString}"
-                                                                                      ^
-Compilation Failed
-
-@ safeStr"test will work by telling the compiler, yes, it is a string ${test.asStr}"
-res6: com.thaj.safe.string.interpolator.SafeString = SafeString("test will work by telling the compiler, yes, it is a string foo,bar")
-
-```

--- a/docs/src/main/tut/secrets.md
+++ b/docs/src/main/tut/secrets.md
@@ -28,8 +28,7 @@ scala> s"The db connection is $dbConn"
 res2: String = The db connection is DbConn(driverstring,Secret(adifficultpassword))
 
 scala> safeStr"The db connection is $dbConn"
-res3: com.thaj.safe.string.interpolator.SafeString = SafeString(The db connection is { password: ******************, driver: driverstring })
-
+res1: com.thaj.safe.string.interpolator.SafeString = SafeString(The db connection is { driver : driverstring, password : ***** })
 
 ```
 
@@ -37,17 +36,19 @@ res3: com.thaj.safe.string.interpolator.SafeString = SafeString(The db connectio
 
 ## Your own secret ?
 
-If you don't want to use `interpolation.Secret` data type and need to use your own, then define `Safe` instance for it.
+If you don't want to use `com.thaj.safe.string.interpolator.Secret` data type and need to use your own, then define `Safe` instance for it.
 
 ```scala
 case class MySecret(value: String) extends AnyVal
 
 implicit val safeMySec: Safe[MySecret] = _ => "****"
 
-val conn = DbConnection("posgr", MySecret("this will be hidden"))
+case class DbConn(driver: String, password: MySecret)
+
+val conn = DbConn("posgr", MySecret("this will be hidden"))
 
 
 scala> safeStr"the db is $conn"
-res1: com.thaj.safe.string.interpolator.SafeString = SafeString(the db is { password: ****, name: posgr })
+res3: com.thaj.safe.string.interpolator.SafeString = SafeString(the db is { driver : posgr, password : **** })
 
 ```

--- a/project/DocSupport.scala
+++ b/project/DocSupport.scala
@@ -28,7 +28,7 @@ object DocSupport {
     micrositeHighlightTheme := "atom-one-light",
     micrositeGithubRepo := "safe-string-interpolation",
     micrositeHomepage := "https://afsalthaj.github.io/safe-string-interpolation",
-    micrositeBaseUrl := "/safe-string-interpolation",
+    micrositeBaseUrl := "iagcl/safe-string-interpolation",
     micrositeGithubOwner := "afsalthaj",
     micrositeGithubRepo := "safe-string-interpolation",
     micrositeGitterChannelUrl := "safe-string-interpolation/community",

--- a/test/src/test/scala/test/com/thaj/safe/string/interpolator/SafeStringSpec.scala
+++ b/test/src/test/scala/test/com/thaj/safe/string/interpolator/SafeStringSpec.scala
@@ -1,7 +1,7 @@
 package test.com.thaj.safe.string.interpolator
 
 import com.thaj.safe.string.interpolator.SafeString._
-import com.thaj.safe.string.interpolator.Secret
+import com.thaj.safe.string.interpolator.{Safe, Secret}
 import org.specs2.{ScalaCheck, Specification}
 import scalaz.{@@, NonEmptyList, Tag}
 import test.com.thaj.safe.string.interpolator.SafeStringSpec.Xxx.{NewTaggedType, StringTT, StringTTT, TaggedType}
@@ -29,20 +29,20 @@ object SafeStringSpec extends Specification with ScalaCheck {
   final case class NestedDummy[A](name: String, secret: Secret, dummy: Dummy)
 
   private def test =
-    prop { (a: String, b: String, c: Int, d: Int) =>
-      val res: String = (c + d).toString
+    prop { (a: String, b: String, c: Int, d: Int, e: Float) =>
+      val res: Int = c + d
       val dummy = Dummy(a, d)
 
-      safeStr"the safe string is, ${a}, ${b}, ${res}, $dummy".string must_===
-        s"the safe string is, $a, ${b.toString}, $res, { age: ${dummy.age.toString}, name: ${dummy.name} }"
+      safeStr"the safe string is, $e, $a, $b, ${res.asStr}, $dummy".string must_===
+        s"the safe string is, $e, $a, ${b.toString}, $res, { name : ${dummy.name}, age : ${dummy.age.toString} }"
     }
 
   private def testSecrets =
     prop { (a: String, b: String) =>
       val dummy = DummyWithSecret(a, Secret(b))
 
-      safeStr"the safe string with password, ${a}, $dummy".string must_===
-        s"the safe string with password, $a, { secret: *****, name: ${a} }"
+      safeStr"the safe string with password, $a, $dummy".string must_===
+        s"the safe string with password, $a, { name : $a, secret : ***** }"
     }
 
   private def tesNestedCaseclass =
@@ -51,7 +51,7 @@ object SafeStringSpec extends Specification with ScalaCheck {
       val nestDummy = NestedDummy(a, Secret(b), dummy)
 
       safeStr"the safe string with password, ${a}, $nestDummy".string must_===
-        s"the safe string with password, $a, { dummy: { name : $a, age : $c }, secret: *****, name: ${dummy.name} }"
+        s"the safe string with password, $a, { name : ${dummy.name}, secret : *****, dummy : { name : $a, age : $c } }"
     }
 
   private def testSafeStrWithNoHardCodedStrings =
@@ -78,21 +78,21 @@ object SafeStringSpec extends Specification with ScalaCheck {
 
   private def testGADT =
     prop { a: String =>
-      safeStr"works for gadt ${TestGadt(NonEmptyList(a, a))}".string must_=== s"works for gadt { list: ${a},${a} }"
+      safeStr"works for gadt ${TestGadt(NonEmptyList(a, a))}".string must_=== s"works for gadt { list : ${a},${a} }"
     }
 
   final case class TestMap(map: Map[String, String])
 
   private def testMap =
     prop { a: String =>
-      safeStr"works for gadt ${TestMap(Map(a -> a))}".string must_=== s"works for gadt { map: ${a} -> ${a} }"
+      safeStr"works for gadt ${TestMap(Map(a -> a))}".string must_=== s"works for gadt { map : ${a} -> ${a} }"
     }
 
   final case class TestMapWithNonEmptyList(mapN: Map[String, NonEmptyList[String]])
 
   private def testMapWithNonEmptyList =
     prop { a: String =>
-      safeStr"works for gadt ${TestMapWithNonEmptyList(Map(a -> NonEmptyList(a, a)))}".string must_=== s"works for gadt { mapN: ${a} -> ${a},${a} }"
+      safeStr"works for gadt ${TestMapWithNonEmptyList(Map(a -> NonEmptyList(a, a)))}".string must_=== s"works for gadt { mapN : ${a} -> ${a},${a} }"
     }
 
   final case class CaseTag(d: StringTTT, f: StringTT)
@@ -108,6 +108,6 @@ object SafeStringSpec extends Specification with ScalaCheck {
 
   private def testMultipleTaggedType =
     prop { a: String =>
-      safeStr"works for taggedtypes ${CaseTag(Tag[String, NewTaggedType](a), Tag[String, TaggedType](a))}".string must_=== s"works for taggedtypes { f: ${a}, d: ${a} }"
+      safeStr"works for taggedtypes ${CaseTag(Tag[String, NewTaggedType](a), Tag[String, TaggedType](a))}".string must_=== s"works for taggedtypes { d : $a, f : $a }"
     }
 }

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "1.2.9"
+version in ThisBuild := "1.3.0"


### PR DESCRIPTION
This will remove the complexity of case class and types that have safe instance being treated separately. All that we need to have is everything that you pass to `safeStr` should have an instance of `Safe`. `Safe` macros, as before, will automatically derive safe instances for products. Coproducts is yet to be handled.